### PR TITLE
Simplifying slog details and labels

### DIFF
--- a/slog/slog.go
+++ b/slog/slog.go
@@ -82,6 +82,12 @@ func (e *Entry) clone() *Entry {
 			next.Labels[k] = v
 		}
 	}
+	if next.Details != nil {
+		next.Details = make(map[string]interface{})
+		for k, v := range e.Details {
+			next.Details[k] = v
+		}
+	}
 	return &next
 }
 
@@ -168,54 +174,48 @@ func (l *Logger) WithSpan(s *trace.Span) *Entry {
 	return l.entry().WithSpan(s)
 }
 
-// Pair to be included as metadata for log entries.
-type Pair struct {
-	Key   string
-	Value interface{}
-}
-
 // WithLabels for a given Entry. Will create a child entry.
-func (e *Entry) WithLabels(labels ...Pair) *Entry {
+func (e *Entry) WithLabels(labels map[string]interface{}) *Entry {
 	c := e.clone()
 	if c.Labels == nil {
 		c.Labels = make(map[string]string)
 	}
-	for _, l := range labels {
-		c.Labels[l.Key] = fmt.Sprint(l.Value)
+	for k, v := range labels {
+		c.Labels[k] = fmt.Sprint(v)
 	}
 	return c
 }
 
 // WithLabels for a given Entry. Will create a child entry.
-func WithLabels(labels ...Pair) *Entry {
-	return std.entry().WithLabels(labels...)
+func WithLabels(labels map[string]interface{}) *Entry {
+	return std.entry().WithLabels(labels)
 }
 
 // WithLabels for a given Entry. Will create a child entry.
-func (l *Logger) WithLabels(labels ...Pair) *Entry {
-	return l.entry().WithLabels(labels...)
+func (l *Logger) WithLabels(labels map[string]interface{}) *Entry {
+	return l.entry().WithLabels(labels)
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func (e *Entry) WithDetails(details ...Pair) *Entry {
+func (e *Entry) WithDetails(details map[string]interface{}) *Entry {
 	c := e.clone()
 	if c.Details == nil {
 		c.Details = make(map[string]interface{})
 	}
-	for _, d := range details {
-		c.Details[d.Key] = d.Value
+	for k, v := range details {
+		c.Details[k] = v
 	}
 	return c
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func WithDetails(details ...Pair) *Entry {
-	return std.entry().WithDetails(details...)
+func WithDetails(details map[string]interface{}) *Entry {
+	return std.entry().WithDetails(details)
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func (l *Logger) WithDetails(details ...Pair) *Entry {
-	return l.entry().WithDetails(details...)
+func (l *Logger) WithDetails(details map[string]interface{}) *Entry {
+	return l.entry().WithDetails(details)
 }
 
 // newLogger with provided options.

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -234,7 +234,7 @@ func TestOperations(t *testing.T) {
 
 func TestLabels(t *testing.T) {
 	// Logger level
-	e := std.WithLabels(Pair{"hello", "world"})
+	e := std.WithLabels(map[string]interface{}{"hello": "world"})
 	e.Info("testing")
 	got := buf.String()
 	buf.Reset()
@@ -245,7 +245,7 @@ func TestLabels(t *testing.T) {
 		t.Errorf("hello label not included\ngot: %v", got)
 	}
 	// Entry level
-	e = e.WithLabels(Pair{"another", 1})
+	e = e.WithLabels(map[string]interface{}{"another": 1})
 	e.Info("testing")
 	got = buf.String()
 	buf.Reset()
@@ -262,7 +262,7 @@ func TestLabels(t *testing.T) {
 		t.Errorf("labels persist when they shouldn't\ngot: %v", got)
 	}
 	// Package level
-	e = WithLabels(Pair{"hello2", "world2"})
+	e = WithLabels(map[string]interface{}{"hello2": "world2"})
 	e.Info("testing")
 	got = buf.String()
 	if !strings.Contains(got, "logging.googleapis.com/labels") {
@@ -272,7 +272,7 @@ func TestLabels(t *testing.T) {
 
 func TestDetails(t *testing.T) {
 	// Logger level
-	e := std.WithDetails(Pair{"hello", "world"})
+	e := std.WithDetails(map[string]interface{}{"hello": "world"})
 	e.Info("testing")
 	got := buf.String()
 	buf.Reset()
@@ -283,7 +283,7 @@ func TestDetails(t *testing.T) {
 		t.Errorf("hello label not included\ngot: %v", got)
 	}
 	// Entry level
-	e = e.WithDetails(Pair{"another", 1})
+	e = e.WithDetails(map[string]interface{}{"another": 1})
 	e.Info("testing")
 	got = buf.String()
 	buf.Reset()
@@ -300,7 +300,7 @@ func TestDetails(t *testing.T) {
 		t.Errorf("labels persist when they shouldn't\ngot: %v", got)
 	}
 	// Package level
-	e = WithDetails(Pair{"hello2", "world2"})
+	e = WithDetails(map[string]interface{}{"hello2": "world2"})
 	e.Info("testing")
 	got = buf.String()
 	if !strings.Contains(got, "details") {


### PR DESCRIPTION
- breaking change: Removing `slog.Pair` and instead just standardizing on `map[string]interface{}`
- closes #19