### PR TITLE
WIP: Add Convenience Methods for Details

### DIFF
--- a/slog/slog.go
+++ b/slog/slog.go
@@ -200,6 +200,26 @@ func (l *Logger) WithLabels(labels map[string]interface{}) *Entry {
 	return l.entry().WithLabels(labels)
 }
 
+// WithDetail for a given Entry. Will create a child entry.
+func (e *Entry) WithDetail(k string, v interface{}) *Entry {
+	c := e.clone()
+	if c.Details == nil {
+		c.Details = make(map[string]interface{})
+	}
+	c.Details[k] = v
+	return c
+}
+
+// WithDetail for a given Entry. Will create a child entry.
+func WithDetail(k string, v interface{}) *Entry {
+	return std.entry().WithDetail(k, v)
+}
+
+// WithDetail for a given Entry. Will create a child entry.
+func (l *Logger) WithDetail(k string, v interface{}) *Entry {
+	return l.entry().WithDetail(k, v)
+}
+
 // WithDetails for a given Entry. Will create a child entry.
 func (e *Entry) WithDetails(details map[string]interface{}) *Entry {
 	c := e.clone()

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -62,7 +62,7 @@ type Entry struct {
 	SpanID         string            `json:"logging.googleapis.com/spanId,omitempty"`
 	TraceSampled   bool              `json:"logging.googleapis.com/trace_sampled,omitempty"`
 	Details        Fields            `json:"details,omitempty"`
-	Err            string            `json:"error,omitempty"`
+	Err            error             `json:"error,omitempty"`
 }
 
 // SourceLocation that originated the log call.
@@ -204,19 +204,19 @@ func (l *Logger) WithLabels(labels Fields) *Entry {
 }
 
 // WithError for a given Entry. Will create a child entry.
-func (e *Entry) WithError(err string) *Entry {
+func (e *Entry) WithError(err error) *Entry {
 	c := e.clone()
 	c.Err = err
 	return c
 }
 
 // WithError for a given Entry. Will create a child entry.
-func WithError(err string) *Entry {
+func WithError(err error) *Entry {
 	return std.entry().WithError(err)
 }
 
 // WithError for a given Entry. Will create a child entry.
-func (l *Logger) WithError(err string) *Entry {
+func (l *Logger) WithError(err error) *Entry {
 	return l.entry().WithError(err)
 }
 

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -62,6 +62,7 @@ type Entry struct {
 	SpanID         string            `json:"logging.googleapis.com/spanId,omitempty"`
 	TraceSampled   bool              `json:"logging.googleapis.com/trace_sampled,omitempty"`
 	Details        Fields            `json:"details,omitempty"`
+	Err            string            `json:"error,omitempty"`
 }
 
 // SourceLocation that originated the log call.
@@ -203,22 +204,19 @@ func (l *Logger) WithLabels(labels Fields) *Entry {
 }
 
 // WithError for a given Entry. Will create a child entry.
-func (e *Entry) WithError(err interface{}) *Entry {
+func (e *Entry) WithError(err string) *Entry {
 	c := e.clone()
-	if c.Details == nil {
-		c.Details = make(Fields)
-	}
-	c.Details["err"] = err
+	c.Err = err
 	return c
 }
 
 // WithError for a given Entry. Will create a child entry.
-func WithError(err interface{}) *Entry {
+func WithError(err string) *Entry {
 	return std.entry().WithError(err)
 }
 
 // WithError for a given Entry. Will create a child entry.
-func (l *Logger) WithError(err interface{}) *Entry {
+func (l *Logger) WithError(err string) *Entry {
 	return l.entry().WithError(err)
 }
 

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -202,6 +202,26 @@ func (l *Logger) WithLabels(labels Fields) *Entry {
 	return l.entry().WithLabels(labels)
 }
 
+// WithError for a given Entry. Will create a child entry.
+func (e *Entry) WithError(err interface{}) *Entry {
+	c := e.clone()
+	if c.Details == nil {
+		c.Details = make(Fields)
+	}
+	c.Details["err"] = err
+	return c
+}
+
+// WithError for a given Entry. Will create a child entry.
+func WithError(err interface{}) *Entry {
+	return std.entry().WithError(err)
+}
+
+// WithError for a given Entry. Will create a child entry.
+func (l *Logger) WithError(err interface{}) *Entry {
+	return l.entry().WithError(err)
+}
+
 // WithDetail for a given Entry. Will create a child entry.
 func (e *Entry) WithDetail(k string, v interface{}) *Entry {
 	c := e.clone()

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -19,6 +19,8 @@ type severity string
 
 type key int
 
+type Fields map[string]interface{}
+
 const (
 	severityDefault   severity = "DEFAULT"
 	severityDebug     severity = "DEBUG"
@@ -50,16 +52,16 @@ type Logger struct {
 // See https://cloud.google.com/logging/docs/agent/configuration#special-fields for reference.
 type Entry struct {
 	logger         *Logger
-	Message        string                 `json:"message"`
-	Severity       severity               `json:"severity,omitempty"`
-	Time           time.Time              `json:"time,omitempty"`
-	Labels         map[string]string      `json:"logging.googleapis.com/labels,omitempty"`
-	SourceLocation *SourceLocation        `json:"logging.googleapis.com/sourceLocation,omitempty"`
-	Operation      *Operation             `json:"logging.googleapis.com/operation,omitempty"`
-	Trace          string                 `json:"logging.googleapis.com/trace,omitempty"`
-	SpanID         string                 `json:"logging.googleapis.com/spanId,omitempty"`
-	TraceSampled   bool                   `json:"logging.googleapis.com/trace_sampled,omitempty"`
-	Details        map[string]interface{} `json:"details,omitempty"`
+	Message        string            `json:"message"`
+	Severity       severity          `json:"severity,omitempty"`
+	Time           time.Time         `json:"time,omitempty"`
+	Labels         map[string]string `json:"logging.googleapis.com/labels,omitempty"`
+	SourceLocation *SourceLocation   `json:"logging.googleapis.com/sourceLocation,omitempty"`
+	Operation      *Operation        `json:"logging.googleapis.com/operation,omitempty"`
+	Trace          string            `json:"logging.googleapis.com/trace,omitempty"`
+	SpanID         string            `json:"logging.googleapis.com/spanId,omitempty"`
+	TraceSampled   bool              `json:"logging.googleapis.com/trace_sampled,omitempty"`
+	Details        Fields            `json:"details,omitempty"`
 }
 
 // SourceLocation that originated the log call.
@@ -87,7 +89,7 @@ func (e *Entry) clone() *Entry {
 		}
 	}
 	if next.Details != nil {
-		next.Details = make(map[string]interface{})
+		next.Details = make(Fields)
 		for k, v := range e.Details {
 			next.Details[k] = v
 		}
@@ -179,7 +181,7 @@ func (l *Logger) WithSpan(s *trace.Span) *Entry {
 }
 
 // WithLabels for a given Entry. Will create a child entry.
-func (e *Entry) WithLabels(labels map[string]interface{}) *Entry {
+func (e *Entry) WithLabels(labels Fields) *Entry {
 	c := e.clone()
 	if c.Labels == nil {
 		c.Labels = make(map[string]string)
@@ -191,12 +193,12 @@ func (e *Entry) WithLabels(labels map[string]interface{}) *Entry {
 }
 
 // WithLabels for a given Entry. Will create a child entry.
-func WithLabels(labels map[string]interface{}) *Entry {
+func WithLabels(labels Fields) *Entry {
 	return std.entry().WithLabels(labels)
 }
 
 // WithLabels for a given Entry. Will create a child entry.
-func (l *Logger) WithLabels(labels map[string]interface{}) *Entry {
+func (l *Logger) WithLabels(labels Fields) *Entry {
 	return l.entry().WithLabels(labels)
 }
 
@@ -204,7 +206,7 @@ func (l *Logger) WithLabels(labels map[string]interface{}) *Entry {
 func (e *Entry) WithDetail(k string, v interface{}) *Entry {
 	c := e.clone()
 	if c.Details == nil {
-		c.Details = make(map[string]interface{})
+		c.Details = make(Fields)
 	}
 	c.Details[k] = v
 	return c
@@ -221,10 +223,10 @@ func (l *Logger) WithDetail(k string, v interface{}) *Entry {
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func (e *Entry) WithDetails(details map[string]interface{}) *Entry {
+func (e *Entry) WithDetails(details Fields) *Entry {
 	c := e.clone()
 	if c.Details == nil {
-		c.Details = make(map[string]interface{})
+		c.Details = make(Fields)
 	}
 	for k, v := range details {
 		c.Details[k] = v
@@ -233,12 +235,12 @@ func (e *Entry) WithDetails(details map[string]interface{}) *Entry {
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func WithDetails(details map[string]interface{}) *Entry {
+func WithDetails(details Fields) *Entry {
 	return std.entry().WithDetails(details)
 }
 
 // WithDetails for a given Entry. Will create a child entry.
-func (l *Logger) WithDetails(details map[string]interface{}) *Entry {
+func (l *Logger) WithDetails(details Fields) *Entry {
 	return l.entry().WithDetails(details)
 }
 

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -272,6 +272,44 @@ func TestLabels(t *testing.T) {
 	}
 }
 
+func TestDetail(t *testing.T) {
+	// Logger level
+	e := std.WithDetail("hello", "world")
+	e.Info("testing")
+	got := buf.String()
+	buf.Reset()
+	if !strings.Contains(got, "details") {
+		t.Errorf("details not included\ngot: %v", got)
+	}
+	if !strings.Contains(got, `"hello":"world"`) {
+		t.Errorf("hello detail not included\ngot: %v", got)
+	}
+	// Entry level
+	e = e.WithDetail("another", 1)
+	e.Info("testing")
+	got = buf.String()
+	buf.Reset()
+	if !strings.Contains(got, `"another":1`) {
+		t.Errorf("another detail not included\ngot: %v", got)
+	}
+	if !strings.Contains(got, `"hello":"world"`) {
+		t.Errorf("original detail removed\ngot: %v", got)
+	}
+	Info("testing")
+	got = buf.String()
+	buf.Reset()
+	if strings.Contains(got, "details") {
+		t.Errorf("details persist when they shouldn't\ngot: %v", got)
+	}
+	// Package level
+	e = WithDetail("hello2", "world2")
+	e.Info("testing")
+	got = buf.String()
+	if !strings.Contains(got, "details") {
+		t.Errorf("details not included\ngot: %v", got)
+	}
+}
+
 func TestDetails(t *testing.T) {
 	// Logger level
 	e := std.WithDetails(map[string]interface{}{"hello": "world"})

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -278,35 +278,35 @@ func TestError(t *testing.T) {
 	e.Info("testing")
 	got := buf.String()
 	buf.Reset()
-	if !strings.Contains(got, "details") {
-		t.Errorf("details not included\ngot: %v", got)
+	if !strings.Contains(got, "error") {
+		t.Errorf("error not included\ngot: %v", got)
 	}
-	if !strings.Contains(got, `"err":"error msg 1"`) {
-		t.Errorf("error message not included\ngot: %v", got)
+	if !strings.Contains(got, `"error":"error msg 1"`) {
+		t.Errorf("error not included\ngot: %v", got)
 	}
 	// Entry level
 	e = e.WithError("error msg 2")
 	e.Info("testing")
 	got = buf.String()
 	buf.Reset()
-	if !strings.Contains(got, `"err":"error msg 2"`) {
-		t.Errorf("error message not included\ngot: %v", got)
+	if !strings.Contains(got, `"error":"error msg 2"`) {
+		t.Errorf("error not included\ngot: %v", got)
 	}
-	if strings.Contains(got, `"err":"error msg 1"`) {
+	if strings.Contains(got, `"error":"error msg 1"`) {
 		t.Errorf("original error not overriden\ngot: %v", got)
 	}
 	Info("testing")
 	got = buf.String()
 	buf.Reset()
-	if strings.Contains(got, "details") {
-		t.Errorf("details persist when they shouldn't\ngot: %v", got)
+	if strings.Contains(got, "error") {
+		t.Errorf("error persist when it shouldn't\ngot: %v", got)
 	}
 	// Package level
 	e = WithError("error msg 3")
 	e.Info("testing")
 	got = buf.String()
-	if !strings.Contains(got, "details") {
-		t.Errorf("details not included\ngot: %v", got)
+	if !strings.Contains(got, "err") {
+		t.Errorf("error not included\ngot: %v", got)
 	}
 }
 

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -272,6 +272,44 @@ func TestLabels(t *testing.T) {
 	}
 }
 
+func TestError(t *testing.T) {
+	// Logger level
+	e := std.WithError("error msg 1")
+	e.Info("testing")
+	got := buf.String()
+	buf.Reset()
+	if !strings.Contains(got, "details") {
+		t.Errorf("details not included\ngot: %v", got)
+	}
+	if !strings.Contains(got, `"err":"error msg 1"`) {
+		t.Errorf("error message not included\ngot: %v", got)
+	}
+	// Entry level
+	e = e.WithError("error msg 2")
+	e.Info("testing")
+	got = buf.String()
+	buf.Reset()
+	if !strings.Contains(got, `"err":"error msg 2"`) {
+		t.Errorf("error message not included\ngot: %v", got)
+	}
+	if strings.Contains(got, `"err":"error msg 1"`) {
+		t.Errorf("original error not overriden\ngot: %v", got)
+	}
+	Info("testing")
+	got = buf.String()
+	buf.Reset()
+	if strings.Contains(got, "details") {
+		t.Errorf("details persist when they shouldn't\ngot: %v", got)
+	}
+	// Package level
+	e = WithError("error msg 3")
+	e.Info("testing")
+	got = buf.String()
+	if !strings.Contains(got, "details") {
+		t.Errorf("details not included\ngot: %v", got)
+	}
+}
+
 func TestDetail(t *testing.T) {
 	// Logger level
 	e := std.WithDetail("hello", "world")

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -3,6 +3,7 @@ package slog
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -273,27 +274,28 @@ func TestLabels(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	errA := errors.New("error msg A")
+	errB := errors.New("error msg B")
 	// Logger level
-	e := std.WithError("error msg 1")
+	e := std.WithError(errA)
 	e.Info("testing")
 	got := buf.String()
 	buf.Reset()
 	if !strings.Contains(got, "error") {
 		t.Errorf("error not included\ngot: %v", got)
 	}
-	if !strings.Contains(got, `"error":"error msg 1"`) {
-		t.Errorf("error not included\ngot: %v", got)
+	if e.Err.Error() != errA.Error() {
+		t.Errorf("error not included\ngot: %v", e.Err.Error())
 	}
 	// Entry level
-	e = e.WithError("error msg 2")
+	e = e.WithError(errB)
 	e.Info("testing")
-	got = buf.String()
 	buf.Reset()
-	if !strings.Contains(got, `"error":"error msg 2"`) {
-		t.Errorf("error not included\ngot: %v", got)
+	if e.Err.Error() != errB.Error() {
+		t.Errorf("error not included\ngot: %v", e.Err.Error())
 	}
-	if strings.Contains(got, `"error":"error msg 1"`) {
-		t.Errorf("original error not overriden\ngot: %v", got)
+	if e.Err.Error() == errA.Error() {
+		t.Errorf("error not included\ngot: %v", e.Err.Error())
 	}
 	Info("testing")
 	got = buf.String()
@@ -302,10 +304,10 @@ func TestError(t *testing.T) {
 		t.Errorf("error persist when it shouldn't\ngot: %v", got)
 	}
 	// Package level
-	e = WithError("error msg 3")
+	e = WithError(errA)
 	e.Info("testing")
 	got = buf.String()
-	if !strings.Contains(got, "err") {
+	if !strings.Contains(got, "error") {
 		t.Errorf("error not included\ngot: %v", got)
 	}
 }


### PR DESCRIPTION
Fixes #21

- adds `type Fields map[string]interface{}`
- adds support for adding a single detail to a slog entry
- adds support for adding a single error detail to a slog entry